### PR TITLE
Arbitrary instance for SafeGen

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        resolver: [ nightly, lts-19, lts-18, lts-17, lts-16, lts-15, lts-14 ]
+        resolver: [ nightly, lts-19, lts-18, lts-17 ]
         os: [ macos-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/Test/QuickCheck/SafeGen.hs
+++ b/src/Test/QuickCheck/SafeGen.hs
@@ -146,14 +146,14 @@ instance QC.Arbitrary a => QC.Arbitrary (SafeGen a) where
       genOne = (,) <$> weight <*> go
       numChoices = [0..5] :: [Int]
       genChoice n = (\a as -> Choice (a :| as)) <$> genOne <*> traverse (const genOne) [1..n]
-      go = oneof [ Pure <$> gen QC.arbitrary
-                 , Gen QC.arbitrary
+      -- each constructor gets an equal weight of 6 to distribute between its subcases
+      go = frequency $
+                 [ (6, Pure <$> gen QC.arbitrary)
+                 , (6, Gen QC.arbitrary)
                  -- TODO: is there something more suitable for Ap here?
-                 , oneof [ Ap (pure id) go
-                         , Ap ((\a b -> oneof [a, b]) <$> go) go
-                         ]
-                 , oneof [ genChoice n | n <- numChoices ]
-                 ]
+                 , (3, Ap (pure id) go)
+                 , (3, Ap ((\a b -> oneof [a, b]) <$> go) go)
+                 ] <> [ (1, genChoice n) | n <- numChoices ]
 
 -- | 'Either' that collects _all_ its failures in a list
 data Validation e a = VLeft (NonEmpty e) | VRight a

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Applicative
 import Control.Monad (forM_)
 import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck as QC
 import Test.QuickCheck.SafeGen as Safe
 
@@ -50,6 +52,8 @@ main =
         let go = Safe.frequency [(1, pure (Leaf ())), (1000, liftA3 Branch go go go)]
         ls <- sample' $ resize 81 $ length <$> runSafeGen go
         maximum ls `shouldBe` 81
+      prop "arbitrary generators terminate" $ \(Blind (sg :: SafeGen Int)) ->
+        generatorTerminates $ runSafeGen sg
       it "generates terms" $
         generatorTerminates . runSafeGen $
           let go :: SafeGen a -> SafeGen (Term a)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -53,7 +53,7 @@ main =
         ls <- sample' $ resize 81 $ length <$> runSafeGen go
         maximum ls `shouldBe` 81
       prop "arbitrary generators terminate" $ \(Blind (sg :: SafeGen Int)) ->
-        generatorTerminates $ runSafeGen sg
+        generatorTerminates $ runSafeGenNoCheck sg
       it "generates terms" $
         generatorTerminates . runSafeGen $
           let go :: SafeGen a -> SafeGen (Term a)


### PR DESCRIPTION
This PR provides `SafeGen` with an `Arbitrary` QuickCheck instance.

Each constructor is given equal weight. For the `Choice` constructor `NonEmpty` lists of lengths 1 to 6 are given equal weight. The individual relative frequencies are sampled from numbers 1 through 9. 